### PR TITLE
Use a temp folder for the output

### DIFF
--- a/process_config.py
+++ b/process_config.py
@@ -49,6 +49,7 @@ def _main() -> int:
     if not output_folder:
         output_folder = tempfile.mkdtemp(prefix=f"{repo.replace('/', '_')}_dotslash")
     logging.info(f"DotSlash files will be written to `{output_folder}")
+    os.makedirs(output_folder, exist_ok=True)
 
     tag = args.tag
     github_server_url = args.server

--- a/process_config.py
+++ b/process_config.py
@@ -442,7 +442,7 @@ def parse_args():
     parser.add_argument(
         "--output",
         help=f"folder where DotSlash files should be written, defaults to $RUNNER_TEMP",
-        default=os.getenv("RUNMNER_TEMP"),
+        default=os.getenv("RUNNER_TEMP"),
     )
 
     return parser.parse_args()

--- a/process_config.py
+++ b/process_config.py
@@ -441,8 +441,8 @@ def parse_args():
 
     parser.add_argument(
         "--output",
-        help=f"folder where DotSlash files should be written, defaults to $GITHUB_WORKSPACE",
-        default=os.getenv("GITHUB_WORKSPACE"),
+        help=f"folder where DotSlash files should be written, defaults to $RUNNER_TEMP",
+        default=os.getenv("RUNMNER_TEMP"),
     )
 
     return parser.parse_args()


### PR DESCRIPTION
This avoids conflicts between repo contents and the result of the action creation process. Not entirely sure if this is the right solution or not

Closes: https://github.com/facebook/dotslash-publish-release/issues/3