### PR TITLE
set check=True when running `gh release upload`

### DIFF
--- a/process_config.py
+++ b/process_config.py
@@ -136,7 +136,8 @@ def _main() -> int:
                     output_file,
                     "--repo",
                     gh_repo_arg,
-                ]
+                ],
+                check=True
             )
 
     return 0


### PR DESCRIPTION
set check=True when running `gh release upload`

It feels like the job should fail if upload fails.
