### PR TITLE
feat: embed build metadata in generated dotslash files

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,56 @@ Each platform entry recognizes the following properties:
 * `hash` must be one of `"blake3"` or `"sha256"`, but it defaults to `"blake3"`,
   so it is optional.
 
+## Action Inputs
+
+This action supports the following inputs:
+
+* `config` (required): Path to .json file in the repo that defines how DotSlash files should be generated.
+* `tag` (required): Tag identifying the release whose assets should be used.
+* `include-build-metadata` (optional): Whether to include build metadata in the generated DotSlash files. Defaults to `true`.
+
+## Build Metadata
+
+By default, the action embeds build metadata in the generated DotSlash files to provide traceability about how and when the files were generated. This metadata includes:
+
+* **Source configuration**: Path to the config file used to generate the DotSlash file
+* **CI information**: Repository, commit SHA, run ID, workflow name, actor, and event type
+* **Generation timestamp**: When the DotSlash file was generated
+* **CI job URL**: Direct link to the GitHub Actions run that generated the file
+
+Example of embedded metadata:
+
+```json
+{
+  "name": "my-tool",
+  "platforms": { ... },
+  "build_metadata": {
+    "source_config": ".github/workflows/dotslash-config.json",
+    "ci": {
+      "github_repository": "owner/repo",
+      "github_sha": "abc123def456",
+      "github_run_id": "987654321",
+      "github_workflow": "Build and Release",
+      "github_actor": "john-doe",
+      "github_event_name": "release",
+      "github_server_url": "https://github.com"
+    },
+    "generated_at": "2025-09-28T15:23:57.878282Z",
+    "ci_job_url": "https://github.com/owner/repo/actions/runs/987654321"
+  }
+}
+```
+
+To disable build metadata inclusion, set `include-build-metadata` to `false`:
+
+```yaml
+- uses: facebook/dotslash-publish-release@v1
+  with:
+    config: .github/workflows/dotslash-config.json
+    tag: ${{ github.event.workflow_run.head_branch }}
+    include-build-metadata: false
+```
+
 ## License
 
 dotslash-publish-release is [MIT licensed](./LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,15 @@ inputs:
   tag:
     description: tag identifying the release whose assets should be used
     required: true
+  include-build-metadata:
+    description: include build metadata in the generated DotSlash files
+    required: false
+    default: 'true'
 runs:
   using: docker
   image: Dockerfile
+  env:
+    INCLUDE_BUILD_METADATA: ${{ inputs.include-build-metadata }}
   args:
     - '--config'
     - ${{ inputs.config }}

--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,11 @@ inputs:
 runs:
   using: docker
   image: Dockerfile
-  env:
-    INCLUDE_BUILD_METADATA: ${{ inputs.include-build-metadata }}
   args:
     - '--config'
     - ${{ inputs.config }}
     - '--tag'
     - ${{ inputs.tag }}
     - '--upload'
+    - '--include-build-metadata'
+    - ${{ inputs.include-build-metadata }}

--- a/process_config.py
+++ b/process_config.py
@@ -137,7 +137,10 @@ def _main() -> int:
 
     # Collect build metadata from the environment
     build_metadata = None
-    include_metadata = args.include_build_metadata and not args.exclude_build_metadata
+    
+    # Convert string argument to boolean
+    include_metadata_str = str(args.include_build_metadata).lower()
+    include_metadata = include_metadata_str not in ["false", "0", "no"] and not args.exclude_build_metadata
     
     # Also check for environment variable (for Docker action support)
     include_metadata_env = os.getenv("INCLUDE_BUILD_METADATA", "true").lower()
@@ -522,9 +525,9 @@ def parse_args():
 
     parser.add_argument(
         "--include-build-metadata",
-        action="store_true",
-        default=True,
-        help="include build metadata in the generated DotSlash files (default: True)",
+        type=str,
+        default="true",
+        help="include build metadata in the generated DotSlash files (default: true)",
     )
 
     parser.add_argument(


### PR DESCRIPTION
- Add build metadata collection from GitHub Actions environment
- Include source config path, CI information, and generation timestamp
- Add CI job URL for traceability back to the generating workflow
- Support disabling metadata via include-build-metadata input
- Update action.yml to expose new input parameter
- Add comprehensive documentation with examples

Fixes #2